### PR TITLE
Add option to set root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ To get started, make sure you have the following installed on your system:
 3. Input your tabbyAPI endpoint URL and admin key and press connect!
 
 ## Command-line Arguments
-| Argument                 | Description                                                  |
-| :----------------------- | :----------------------------------------------------------- |
-| `-h` or`--help`          |  Show this help message and exit                             |
-| `-p` or `--port`         |  Specify port to host the WebUI on (default 7860)            |
-| `-l` or `--listen`       |  Share WebUI link via LAN                                    |
-| `-s` or `--share`        |  Share WebUI link remotely via Gradio's built in tunnel      |
-| `-a` or `--autolaunch`   |  Launch browser after starting WebUI                         |
-| `-e` or `--endpoint_url` |  TabbyAPI endpoint URL (default http://localhost:5000)       |
-| `-k` or `--admin_key`    |  TabbyAPI admin key, connect automatically on launch         |
+| Argument                 | Description                                                                                     |
+| :----------------------- | :---------------------------------------------------------------------------------------------- |
+| `-h` or`--help`          | Show this help message and exit                                                                 |
+| `-p` or `--port`         | Specify port to host the WebUI on (default 7860)                                                |
+| `-l` or `--listen`       | Share WebUI link via LAN                                                                        |
+| `-s` or `--share`        | Share WebUI link remotely via Gradio's built in tunnel                                          |
+| `-a` or `--autolaunch`   | Launch browser after starting WebUI                                                             |
+| `-e` or `--endpoint_url` | TabbyAPI endpoint URL (default http://localhost:5000)                                           |
+| `-k` or `--admin_key`    | TabbyAPI admin key, connect automatically on launch                                             |
+| `-r` or `--root_path`    | Sets the root path for the Gradio application. Useful if running Gradio behind a reverse proxy. |

--- a/webui.py
+++ b/webui.py
@@ -59,6 +59,13 @@ parser.add_argument(
     default=None,
     help="TabbyAPI admin key, connect automatically on launch",
 )
+parser.add_argument(
+    "-r",
+    "--root_path",
+    type=str,
+    default=None,
+    help="Root path",
+)
 args = parser.parse_args()
 if args.listen:
     host_url = "0.0.0.0"
@@ -1055,4 +1062,5 @@ webui.launch(
     server_name=host_url,
     server_port=args.port,
     share=args.share,
+    root_path=args.root_path,
 )


### PR DESCRIPTION
This is useful e.g. when you want to run the UI behind a reverse proxy (e.g. `domain.tld/ui/`).